### PR TITLE
squad-sre-200 - Adicionar helm chart do metabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ NOTE: one custom thing that we add to charts is the extra-manifest.yaml that all
 | chart | based on 
 | -- | -- | 
 | consul | https://artifacthub.io/packages/helm/hashicorp/consul
+| metabase | https://artifacthub.io/packages/helm/metabase-helm/metabase
 | prometheus-elasticsearch-exporter | https://artifacthub.io/packages/helm/prometheus-community/prometheus-elasticsearch-exporter
 | prometheus-kafka-exporter | https://artifacthub.io/packages/helm/prometheus-community/prometheus-kafka-exporter
 | raw | https://github.com/bedag/helm-charts/tree/master/charts/raw

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+appVersion: v0.46.0
+description: The easy, open source way for everyone in your company to ask questions
+  and learn from data.
+home: http://www.metabase.com/
+icon: http://www.metabase.com/images/logo.svg
+maintainers:
+- email: aminaleahmad@yahoo.com
+  name: aminaleahmad
+name: metabase
+sources:
+- https://github.com/metabase/metabase
+version: 2.7.1

--- a/charts/metabase/OWNERS
+++ b/charts/metabase/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- pmint93
+reviewers:
+- pmint93

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -1,0 +1,1 @@
+# metabase-helm

--- a/charts/metabase/templates/NOTES.txt
+++ b/charts/metabase/templates/NOTES.txt
@@ -1,0 +1,32 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.hostname }}
+  http://{{- .Values.ingress.hostname }}
+{{- else if .Values.route.enabled }}
+  {{- if .Values.route.host }}
+    {{- if not (empty .Values.route.tls) }}
+  https://{{- .Values.route.host }}
+    {{- else }}
+  http://{{- .Values.route.host }}
+    {{- end }}
+  {{- else }}
+  export ROUTE_HOST=$(oc get route -n {{ .Release.Namespace }} {{ template "metabase.fullname" . }} -o jsonpath="{.spec.host}")
+    {{- if not (empty .Values.route.tls) }}
+  echo https://$ROUTE_HOST
+    {{- else }}
+  echo http://$ROUTE_HOST
+    {{- end }}
+  {{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "metabase.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "metabase.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "metabase.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "metabase.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- end }}

--- a/charts/metabase/templates/_helpers.tpl
+++ b/charts/metabase/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "metabase.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "metabase.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the apiVersion of deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "metabase.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "metabase.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/metabase/templates/config.yaml
+++ b/charts/metabase/templates/config.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "metabase.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{- if .Values.log4jProperties }}
+  log4j.properties:
+{{ toYaml .Values.log4jProperties | indent 4}}
+  {{- end}}
+  {{- if .Values.log4j2XML }}
+  log4j2.xml:
+{{ toYaml .Values.log4j2XML | indent 4}}
+  {{- end}}

--- a/charts/metabase/templates/database-pvc.yaml
+++ b/charts/metabase/templates/database-pvc.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.persistence.enabled }}
+{{- $h2database := .Values.persistence.persistentVolumeClaim.h2database -}}
+{{- if not $h2database.existingClaim }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  annotations:
+  {{- range $key, $value := $h2database.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- if eq .Values.persistence.resourcePolicy "keep" }}
+    helm.sh/resource-policy: keep
+  {{- end }}
+  labels:
+    component: h2database
+spec:
+  accessModes: 
+    - {{ $h2database.accessMode }}
+  resources:
+    requests:
+      storage: {{ $h2database.size }}
+  {{- if $h2database.storageClass }}
+    {{- if eq "-" $h2database.storageClass }}
+  storageClassName: ""
+    {{- else }}
+  storageClassName: {{ $h2database.storageClass }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/metabase/templates/database-secret.yaml
+++ b/charts/metabase/templates/database-secret.yaml
@@ -1,0 +1,28 @@
+{{- if not .Values.database.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "metabase.fullname" . }}-database
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  {{- if .Values.database.encryptionKey }}
+  encryptionKey: {{ .Values.database.encryptionKey | b64enc | quote }}
+  {{- end }}
+  {{- if (ne (.Values.database.type | lower) "h2") }}
+    {{- if .Values.database.connectionURI }}
+  connectionURI: {{ .Values.database.connectionURI | b64enc | quote }}
+    {{- end }}
+    {{- if .Values.database.username }}
+  username: {{ .Values.database.username | b64enc | quote }}
+    {{- end }}
+    {{- if .Values.database.password }}
+  password: {{ .Values.database.password | b64enc | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -1,0 +1,295 @@
+apiVersion: {{ template "deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.deploymentLabels }}
+    {{- toYaml .Values.deploymentLabels | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.deploymentAnnotations | trim | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "metabase.name" . }}
+  replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+{{ toYaml . | trim | indent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | trim | indent 8 }}
+        {{- end }}
+      labels:
+        app: {{ template "metabase.name" . }}
+        release: {{ .Release.Name }}
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | trim | indent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.extraInitContainers }}
+      initContainers:
+        {{ toYaml .Values.extraInitContainers | nindent 8 }}
+      {{- end }}
+      {{- if gt (len .Values.image.pullSecrets) 0 }}
+      imagePullSecrets:
+        {{- range .Values.image.pullSecrets }}
+        - name: {{ . | quote }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- with .Values.image.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: MB_JETTY_HOST
+            value: {{ .Values.listen.host | quote }}
+          - name: MB_JETTY_PORT
+            value: {{ .Values.listen.port | quote }}
+          {{- if .Values.monitoring.enabled }}
+          - name: MB_PROMETHEUS_SERVER_PORT
+            value: {{ .Values.monitoring.port  | quote }}
+          {{- end }}
+          {{- if .Values.ssl.enabled }}
+          - name: MB_JETTY_SSL
+            value: true
+          - name: MB_JETTY_SSL_Port
+            value: {{ .Values.ssl.port | quote }}
+          - name: MB_JETTY_SSL_Keystore
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "metabase.fullname" . }}-ssl
+                key: keystore
+          - name: MB_JETTY_SSL_Keystore_Password
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "metabase.fullname" . }}-ssl
+                key: password
+          {{- end }}
+          {{- if .Values.jetty }}
+            {{- range $key, $value := .Values.jetty }}
+          - name: MB_JETTY_{{ $key | upper }}
+            value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          - name: MB_DB_TYPE
+            value: {{ .Values.database.type | lower }}
+          {{- if .Values.database.file }}
+          - name: MB_DB_FILE
+            value: {{ .Values.database.file }}
+          {{- end }}
+          {{- if or .Values.database.existingSecretEncryptionKeyKey .Values.database.encryptionKey }}
+          - name: MB_ENCRYPTION_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ or .Values.database.existingSecret (printf "%s-database" (include "metabase.fullname" .))}}
+                key: {{ or .Values.database.existingSecretEncryptionKeyKey "encryptionKey" }}
+          {{- end }}
+          {{- if ne (.Values.database.type | lower) "h2" }}
+            {{- if or .Values.database.existingSecretConnectionURIKey .Values.database.connectionURI }}
+          - name: MB_DB_CONNECTION_URI
+            valueFrom:
+              secretKeyRef:
+                name: {{ or .Values.database.existingSecret (printf "%s-database" (include "metabase.fullname" .)) }}
+                key: {{ or .Values.database.existingSecretConnectionURIKey "connectionURI" }}
+            {{- else }}
+          - name: MB_DB_HOST
+            value: {{ .Values.database.host | quote }}
+          - name: MB_DB_PORT
+            value: {{ .Values.database.port | quote }}
+          - name: MB_DB_DBNAME
+            value: {{ .Values.database.dbname | quote }}
+            {{- end }}
+            {{- if or .Values.database.existingSecretUsernameKey .Values.database.username }}
+          - name: MB_DB_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ or .Values.database.existingSecret (printf "%s-database" (include "metabase.fullname" .)) }}
+                key: {{ or .Values.database.existingSecretUsernameKey "username" }}
+            {{- end }}
+            {{- if or .Values.database.existingSecretPasswordKey .Values.database.password }}
+          - name: MB_DB_PASS
+            valueFrom:
+              secretKeyRef:
+                name: {{ or .Values.database.existingSecret (printf "%s-database" (include "metabase.fullname" .)) }}
+                key: {{ or .Values.database.existingSecretPasswordKey "password" }}
+            {{- end }}
+          {{- end }}
+          - name: MB_PASSWORD_COMPLEXITY
+            value: {{ .Values.password.complexity }}
+          - name: MB_PASSWORD_LENGTH
+            value: {{ .Values.password.length | quote }}
+          - name: JAVA_TIMEZONE
+            value: {{ .Values.timeZone }}
+          {{- if .Values.javaOpts }}
+          - name: JAVA_OPTS
+            value: {{ .Values.javaOpts | quote }}
+          {{- else }}
+            {{- if .Values.log4jProperties }}
+          - name: JAVA_OPTS
+            value: "-Dlog4j.configuration=file:/tmp/conf/log4j.properties"
+            {{- end }}
+            {{- if .Values.log4j2XML }}
+          - name: JAVA_OPTS
+            value: "-Dlog4j.configurationFile=file:/tmp/conf/log4j2.xml"
+            {{- end }}
+          {{- end }}
+          {{- if .Values.pluginsDirectory }}
+          - name: MB_PLUGINS_DIR
+            value: {{ .Values.pluginsDirectory | quote }}
+          {{- end }}
+          - name: MB_EMOJI_IN_LOGS
+            value: {{ .Values.emojiLogging | quote }}
+          - name: MB_COLORIZE_LOGS
+            value: {{ .Values.colorLogging | quote }}
+          {{- if .Values.siteUrl }}
+          - name: MB_SITE_URL
+            value: {{ .Values.siteUrl | quote }}
+          {{- end }}
+          {{- if .Values.session.maxSessionAge }}
+          - name: MAX_SESSION_AGE
+            value: {{ .Values.session.maxSessionAge | quote }}
+          {{- end }}
+          {{- if .Values.session.sessionCookies }}
+          - name: MB_SESSION_COOKIES
+            value: {{ .Values.session.sessionCookies | quote }}
+          {{- end }}
+          {{- if .Values.session.cookieSameSite }}
+          - name: MB_COOKIE_SAMESITE
+            value: {{ .Values.session.cookieSameSite | quote }}
+          {{- end }}
+          {{- if gt (len .Values.extraEnv) 0 }}
+          {{- .Values.extraEnv | toYaml | nindent 10 }}
+          {{- end }}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+            {{- if .Values.monitoring.enabled }}
+            - containerPort: {{ .Values.monitoring.port }}
+              name: metrics
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          {{- if or .Values.log4jProperties .Values.log4j2XML .Values.persistence.enabled (ne (len .Values.extraVolumeMounts) 0) }}
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: h2database-data
+              mountPath: {{ default "/metabase.db" .Values.database.file }}
+            {{- end }}
+            {{- if or .Values.log4jProperties .Values.log4j2XML }}
+            - name: config
+              mountPath: /tmp/conf/
+            {{- end }}
+            {{- if ne (len .Values.extraVolumeMounts) 0 }}
+              {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        {{- if gt (len .Values.database.googleCloudSQL.instanceConnectionNames) 0 }}
+        - name: cloudsql-proxy
+          image: "gcr.io/cloudsql-docker/gce-proxy:{{ or .Values.database.googleCloudSQL.sidecarImageTag "latest" }}"
+          command:
+            - "/cloud_sql_proxy"
+            - "-instances={{ join "," .Values.database.googleCloudSQL.instanceConnectionNames }}"
+            - "-term_timeout=10s"
+            - "-structured_logs"
+            - "-use_http_health_check"
+            - "-enable_iam_login"
+          securityContext:
+            runAsNonRoot: true
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 8090
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 2
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 8090
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 2
+          startupProbe:
+            httpGet:
+              path: /startup
+              port: 8090
+            periodSeconds: 1
+            timeoutSeconds: 5
+            failureThreshold: 20
+          resources:
+{{ toYaml .Values.database.googleCloudSQL.resources | indent 12 }}
+        {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      {{- if .Values.priorityClass}}
+      priorityClass: {{ .Values.priorityClass }}
+      {{- end }}
+      serviceAccountName: {{ template "metabase.serviceAccountName" . }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: h2database-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.persistentVolumeClaim.h2database.existingClaim | default (include "metabase.fullname" .) }}
+        {{- else }}
+        - name: h2database-data
+          emptyDir: {}
+        {{- end }}
+        {{- if or .Values.log4jProperties .Values.log4j2XML }}
+        - name: config
+          configMap:
+            name: {{ template "metabase.fullname" . }}-config
+            items:
+            {{- if .Values.log4jProperties }}
+            - key: log4j.properties
+              path: log4j.properties
+            {{- end }}
+            {{- if .Values.log4j2XML}}
+            - key: log4j2.xml
+              path: log4j2.xml
+            {{- end }}
+        {{- end }}
+        {{- if ne (len .Values.extraVolumes) 0 }}
+          {{ toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}

--- a/charts/metabase/templates/extra-manifests.yaml
+++ b/charts/metabase/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/metabase/templates/ingress.yaml
+++ b/charts/metabase/templates/ingress.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "metabase.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $ingressPathType := .Values.ingress.pathType -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            pathType: {{ $ingressPathType }}
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- else -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end }}
+{{- end -}}

--- a/charts/metabase/templates/route.yaml
+++ b/charts/metabase/templates/route.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.route.enabled -}}
+{{- $serviceName := include "metabase.fullname" . -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- range $key, $value := .Values.route.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  annotations:
+    {{- range $key, $value := .Values.route.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  host: {{ .Values.route.host | quote }}
+  path: {{ .Values.route.path }}
+  wildcardPolicy: {{ .Values.route.wildcardPolicy }}
+{{- if not (empty .Values.route.tls) }}
+  tls:
+{{- with .Values.route.tls }}
+    termination: {{ .termination }}
+    insecureEdgeTerminationPolicy: {{ .insecureEdgeTerminationPolicy }}
+    {{- with .key }}
+    key: |
+{{ . | indent 6 }}
+    {{- end }}
+    {{- with .certificate }}
+    certificate: |
+{{ . | indent 6 }}
+    {{- end }}
+    {{- with .caCertificate }}
+    caCertificate: |
+{{ . | nindent 6 }}
+    {{- end }}
+    {{- with .destinationCACertificate }}
+    destinationCACertificate: |
+{{ . | nindent 6 }}
+    {{- end }}
+{{- end }}
+{{- end }}
+  to:
+    kind: Service
+    name: {{ $serviceName }}
+{{- end }}

--- a/charts/metabase/templates/securitygrouppolicy.yaml
+++ b/charts/metabase/templates/securitygrouppolicy.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.awsEKS.sgp.enabled -}}
+apiVersion: vpcresources.k8s.aws/v1beta1
+kind: SecurityGroupPolicy
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "metabase.name" . }}
+      release: {{ .Release.Name }}
+  securityGroups:
+    groupIds:
+      {{- range .Values.awsEKS.sgp.sgIds }}
+      - {{ . | quote }}
+      {{- end }}
+{{- end }}

--- a/charts/metabase/templates/service.yaml
+++ b/charts/metabase/templates/service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+{{- if .Values.service.loadBalancerSourceRanges}}
+  loadBalancerSourceRanges:
+{{toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+{{- end}}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+{{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+{{- end}}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "metabase.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/metabase/templates/serviceaccount.yaml
+++ b/charts/metabase/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "metabase.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/metabase/templates/ssl-secret.yaml
+++ b/charts/metabase/templates/ssl-secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.ssl.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "metabase.fullname" . }}-ssl
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  keystore: {{ .Values.ssl.keystore | b64enc | quote }}
+  password: {{ .Values.ssl.keyStorePassword | b64enc | quote }}
+{{- end }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -1,0 +1,300 @@
+# Currently Metabase is not horizontly scalable. See
+# https://github.com/metabase/metabase/issues/1446 and
+# https://github.com/metabase/metabase/issues/2754
+# NOTE: Should remain 1
+replicaCount: 1
+deploymentAnnotations: {}
+deploymentLabels: {}
+podAnnotations: {}
+podLabels: {}
+image:
+  repository: metabase/metabase
+  tag: v0.46.0
+  command: []
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+## String to fully override metabase.fullname template
+##
+# fullnameOverride:
+
+# Config Jetty web server
+listen:
+  host: "0.0.0.0"
+  port: 3000
+
+monitoring:
+  enabled: false
+  port: 9191
+ssl:
+  # If you have an ssl certificate and would prefer to have Metabase run over HTTPS
+  enabled: false
+  # port: 8443
+  # keyStore: |-
+  #   << JKS KEY STORE >>
+  # keyStorePassword: storepass
+jetty:
+#  maxThreads: 254
+#  minThreads: 8
+#  maxQueued: -1
+#  maxIdleTime: 60000
+
+# Backend database
+database:
+  # Database type (h2 / mysql / postgres), default: h2
+  type: h2
+  ## Specify file to store H2 database.  You will also have to back this with a volume (cf. extraVolume and extraVolumeMounts)!
+  # file:
+  # encryptionKey: << YOUR ENCRYPTION KEY OR LEAVE BLANK AND USE EXISTING SECRET >>
+  ## Only need when you use mysql / postgres
+  # host:
+  # port:
+  # dbname:
+  # username:
+  # password:
+  ## Alternatively, use a connection URI for full configurability. Example for SSL enabled Postgres.
+  # connectionURI: postgres://<host>:<port>/<database>?user=<username>&password=<password>&ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory
+  ## If a secret with the database credentials already exists, use the following values:
+  # existingSecret:
+  # existingSecretUsernameKey:
+  # existingSecretPasswordKey:
+  # existingSecretConnectionURIKey:
+  # existingSecretEncryptionKeyKey:
+  ## One or more Google Cloud SQL database instances can be made available to Metabase via the *Cloud SQL Auth proxy*.
+  ## These can be used for Metabase's internal database (by specifying `host: localhost` and the port above), or as
+  ## additional databases (configured at Admin → Databases). Workload Identity should be used for authentication, so
+  ## that when `serviceAccount.create=true`, `serviceAccount.annotations` should contain:
+  ##   iam.gke.io/gcp-service-account: your-gsa@email
+  ## Ref: https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine
+  googleCloudSQL:
+    ## Found in Cloud Console "Cloud SQL Instance details" or using `gcloud sql instances describe INSTANCE_ID`
+    ## example format: $project:$region:$instance=tcp:$port
+    ## Each connection must have a unique TCP port.
+    instanceConnectionNames: []
+    ## Option to use a specific version of the *Cloud SQL Auth proxy* sidecar image.
+    ## ref: https://console.cloud.google.com/gcr/images/cloudsql-docker/GLOBAL/gce-proxy
+    # sidecarImageTag: latest
+    ## ref: https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine#running_the_as_a_sidecar
+    resources: {}
+
+password:
+  # Changing Metabase password complexity:
+  # weak: no character constraints
+  # normal: at least 1 digit (default)
+  # strong: minimum 8 characters w/ 2 lowercase, 2 uppercase, 1 digit, and 1 special character
+  complexity: normal
+  length: 6
+
+timeZone: UTC
+emojiLogging: true
+colorLogging: true
+# javaOpts:
+# pluginsDirectory: /plugins
+# siteUrl:
+
+session:
+  {}
+  # maxSessionAge:
+  # sessionCookies:
+  # cookieSameSite:
+
+# specify init containers, e.g. for module download
+extraInitContainers: []
+#  - name: download-modules
+#    image: "curlimages/curl:7.70.0"
+#    imagePullPolicy: "IfNotPresent"
+#    volumeMounts:
+#      - name: plugins
+#        mountPath: /plugins
+#    workingDir: /plugins
+#    command:
+#      - "/bin/sh"
+#      - "-ec"
+#      - |
+#        curl -Lso /plugins/athena.metabase-driver.jar \
+#                  https://github.com/dacort/metabase-athena-driver/releases/download/v1.1.0/athena.metabase-driver.jar
+
+extraVolumeMounts: []
+#  - name: plugins
+#    mountPath: /plugins
+#    readOnly: false
+
+extraVolumes: []
+#  - name: plugins
+#    emptyDir: {}
+
+livenessProbe:
+  path: /api/health
+  initialDelaySeconds: 120
+  timeoutSeconds: 30
+  failureThreshold: 6
+
+readinessProbe:
+  path: /api/health
+  initialDelaySeconds: 30
+  timeoutSeconds: 3
+  periodSeconds: 5
+
+service:
+  name: metabase
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 3000
+  # Used to fix NodePort when service.type: NodePort.
+  nodePort:
+  annotations:
+    {}
+    # Used to add custom annotations to the Service.
+    # service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
+ingress:
+  enabled: false
+  # The ingress class name, if you use multiple ingress controllers:
+  # className: ...
+  # Used to create Ingress record (should used with service.type: ClusterIP).
+  hosts:
+    - "*"
+    # - metabase.domain.com
+  # The ingress path. Useful to host metabase on a subpath, such as `/metabase`.
+  path: /
+  pathType: Prefix
+  labels:
+    # Used to add custom labels to the Ingress
+    # Useful if for example you have multiple Ingress controllers and want your Ingress controllers to bind to specific Ingresses
+    # traffic: internal
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: metabase-tls
+    #   hosts:
+    #     - metabase.domain.com
+
+route:
+  enabled: false
+  annotations:
+    {}
+    # haproxy.router.openshift.io/timeout: "60s"
+  # host: ""
+  path: ""
+  wildcardPolicy: "None"
+  tls:
+    {}
+    # termination: "Edge"
+    # insecureEdgeTerminationPolicy: "Redirect"
+    # key: ""
+    # certificate: ""
+    # caCertificate: ""
+    # destinationCACertificate: ""
+
+# A custom log4j2.xml file can be provided using a multiline YAML string.
+# See https://github.com/metabase/metabase/blob/master/resources/log4j2.xml
+#
+# log4j2XML:
+
+# DEPRECATED; A custom log4j.properties file can be provided using a multiline YAML string.
+# See https://github.com/metabase/metabase/blob/master/resources/log4j.properties
+#
+# log4jProperties:
+
+# The deployment strategy to use
+# https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec
+# strategy:
+#   type: "Recreate"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+# The persistence is enabled by default and a default StorageClass
+# is needed in the k8s cluster to provision volumes dynamically.
+# Specify another StorageClass in the "storageClass" or set "existingClaim"
+# if you already have existing persistent volumes to use
+persistence:
+  enabled: true
+  # Setting it to "keep" to avoid removing PVCs during a helm delete
+  # operation. Leaving it empty will delete PVCs after the chart deleted
+  resourcePolicy: "keep"
+  persistentVolumeClaim:
+    h2database:
+      # Use the existing PVC which must be created manually before bound,
+      # and specify the "subPath" if the PVC is shared with other components
+      existingClaim: ""
+      # Specify the "storageClass" used to provision the volume. Or the default
+      # StorageClass will be used (the default).
+      # Set it to "-" to disable dynamic provisioning
+      storageClass: ""
+      accessMode: ReadWriteOnce
+      size: 5Gi
+      annotations: {}
+
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+#
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Affinity for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+## PriorityClass for pod assignment
+## ref:
+## https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
+## priorityClass: ""
+
+## AWS Security Group Policy (EKS)
+## ref: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html
+##
+awsEKS:
+  sgp:
+    enabled: false
+    # AWS Security Group IDs to attach to the pod
+    # sgIds:
+    #   - sg-abc123
+    #   - sg-xyz456
+
+extraEnv: {}
+#  - name: MB_CHECK_FOR_UPDATES
+#    value: false
+#  - name: MB_ADMIN_EMAIL
+#    valueFrom:
+#      configMapKeyRef:
+#        name: metabase
+#        key: email
+
+extraObjects: []
+  # - apiVersion: "kubernetes-client.io/v1"
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: grafana-secrets
+  #   spec:
+  #     backendType: gcpSecretsManager
+  #     data:
+  #       - key: grafana-admin-password
+  #         name: adminPassword


### PR DESCRIPTION
## O que foi feito
- Adicionado o helm chart do Metabase com o parâmetro extra `extraObjects`;
- Atualizado o README.md para creditar o autor do helm chart.

## Importante
- A personalização com o parâmetro `extraObjects` está no arquivo `values.yaml` (linha [291](https://github.com/lojaintegrada/iac-charts/pull/1/files#diff-0e0b54646437768306c254418b161ff2f8d0a072c2b28041b656474c222e9ae3R291) ) e no arquivo [`extra-manifests.yaml`](https://github.com/lojaintegrada/iac-charts/pull/1/files#diff-6419c2afcf74d2798ca23740a6934cbf6786b9d82b81c5b4431f9e92b1e99731).
