### PR TITLE
squad-sre-200 - Atualizar versão do metabase para 0.47.0

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.46.0
+appVersion: v0.47.0
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 home: http://www.metabase.com/

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -9,7 +9,7 @@ podAnnotations: {}
 podLabels: {}
 image:
   repository: metabase/metabase
-  tag: v0.46.0
+  tag: v0.47.0
   command: []
   pullPolicy: IfNotPresent
   pullSecrets: []


### PR DESCRIPTION
## O que foi feito
Atualizada a versão do metabase para `0.47.0`, a mesma que é usada no metabase do Pagali.